### PR TITLE
Fix memory management errors caused by not retaining the arguments on an...

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.h
+++ b/Source/OCMock/NSInvocation+OCMAdditions.h
@@ -9,6 +9,8 @@
 
 - (id)getArgumentAtIndexAsObject:(int)argIndex;
 
+- (BOOL)isArgumentAtIndexAnObject:(int)argIndex;
+
 - (NSString *)invocationDescription;
 
 - (NSString *)argumentDescriptionAtIndex:(int)argIndex;

--- a/Source/OCMock/NSInvocation+OCMAdditions.h
+++ b/Source/OCMock/NSInvocation+OCMAdditions.h
@@ -9,7 +9,7 @@
 
 - (id)getArgumentAtIndexAsObject:(int)argIndex;
 
-- (BOOL)isArgumentAtIndexAnObject:(int)argIndex;
+- (BOOL)argumentAtIndexIsObject:(int)argIndex;
 
 - (NSString *)invocationDescription;
 

--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -9,6 +9,16 @@
 
 @implementation NSInvocation(OCMAdditions)
 
+- (BOOL)isArgumentAtIndexAnObject:(int)argIndex
+{
+    const char *argType = OCMTypeWithoutQualifiers([[self methodSignature] getArgumentTypeAtIndex:argIndex]);
+
+    if((strlen(argType) > 1) && (strchr("{^", argType[0]) == NULL) && (strcmp("@?", argType) != 0))
+        [NSException raise:NSInvalidArgumentException format:@"Cannot handle argument type '%s'.", argType];
+
+    return argType[0] == '@' || argType[0] == '#';
+}
+
 - (id)getArgumentAtIndexAsObject:(int)argIndex
 {
 	const char *argType = OCMTypeWithoutQualifiers([[self methodSignature] getArgumentTypeAtIndex:argIndex]);

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -93,9 +93,9 @@
 	[exceptions release];
 
     for (NSInvocation *invocation in invocations) {
-        [self _performBlock:^(id object) {
+        [self _enumerateObjectArgumentsOfInvocation:invocation usingBlock:^(id object) {
             [object release];
-        } onObjectArgumentsOfInvocation:invocation];
+        }];
     }
 	[invocations release];
 
@@ -237,9 +237,9 @@
     // also retains the target of the invocation (which is ourselves).
     // Because we retain the invocation, this results in a retain cycle.
     // Only retain the arguments here.
-    [self _performBlock:^(id object) {
+    [self _enumerateObjectArgumentsOfInvocation:anInvocation usingBlock:^(id object) {
         [object retain];
-    } onObjectArgumentsOfInvocation:anInvocation];
+    }];
 
     [invocations addObject:anInvocation];
 	
@@ -345,15 +345,15 @@
 }
 
 typedef void (^OCMockInvocationObjectArgumentBlock)(id object);
-- (void)_performBlock:(OCMockInvocationObjectArgumentBlock)block onObjectArgumentsOfInvocation:(NSInvocation *)anInvocation;
-{
+
+- (void)_enumerateObjectArgumentsOfInvocation:(NSInvocation *)anInvocation usingBlock:(OCMockInvocationObjectArgumentBlock)block {
 
     NSUInteger numberOfArguments = anInvocation.methodSignature.numberOfArguments;
 
     // Self and _cmd are the first two arguments, which we don't care about.
     // Start at 2.
     for (NSUInteger i = 2; i < numberOfArguments; i++) {
-        if (![anInvocation isArgumentAtIndexAnObject:i]) {
+        if (![anInvocation argumentAtIndexIsObject:i]) {
             continue;
         }
 


### PR DESCRIPTION
... NSInvocation that we're caching.

